### PR TITLE
Fix retryUntilSuccess Timeout

### DIFF
--- a/install.py
+++ b/install.py
@@ -21,6 +21,7 @@ def retryUntilSuccess(func, timeout = 0):
             return
         except:
             time.sleep(0.1)
+    raise RuntimeError("Retry timed out.")
 
 
 def getProcessPath(processName):


### PR DESCRIPTION
Raise a RuntimeError when retryUntilSuccess times out to indicate that the retry has not succeeded. This fixes #6.

Without this retryUntilSuccess would appear to have completed successfully regardless timing out.