### PR TITLE
Force set ContentFolder registry key

### DIFF
--- a/install.py
+++ b/install.py
@@ -99,7 +99,10 @@ def prepareContentFolder():
     content_folder = getStudioFolderPath() + r"\\content/"
 
     def func():
-        regKey = winreg.OpenKey(winreg.HKEY_CURRENT_USER, r'Software\\Roblox\\RobloxStudio', access=winreg.KEY_WRITE)
+        try:
+            regKey = winreg.OpenKeyEx(winreg.HKEY_CURRENT_USER, r'Software\\Roblox\\RobloxStudio', access=winreg.KEY_WRITE)
+        except:
+            regKey = winreg.CreateKeyEx(winreg.HKEY_CURRENT_USER, r'Software\\Roblox\\RobloxStudio', access=winreg.KEY_WRITE)
         winreg.SetValueEx(regKey, r'ContentFolder', 0, winreg.REG_SZ, content_folder)
         winreg.CloseKey(regKey)
 

--- a/install.py
+++ b/install.py
@@ -76,36 +76,30 @@ def prepareStudioLogin():
     retryUntilSuccess(func)
 
 
-def requestKillStudioProcess():
-    log('Sending terminate signal to RobloxStudioBeta')
-    os.system("taskkill /im RobloxStudioBeta.exe")
-
-
 def forceKillStudioProcess():
     log('Forcefully terminate RobloxStudioBeta.exe')
-    for proc in psutil.process_iter():
-        if proc.name() == "RobloxStudioBeta.exe":
-            proc.kill()
+    os.system("taskkill /f /im RobloxStudioBeta.exe")
 
 
-def waitForContentPath():
-    log('Waiting for the content path to be registered')
+versions_dir = r"C:\\Program Files (x86)\\Roblox\\Versions\\"
 
-    # The content path is used by applications like run-in-roblox to identify Studio's install directory
-    # These keys aren't created until studio closes, so keep retrying until they exist
+
+def getStudioFolderPath():
+    for child in os.listdir(versions_dir):
+        child_path = versions_dir + child
+        if os.path.exists(child_path + r"\\RobloxStudioBeta.exe"):
+            return child_path
+
+
+def prepareContentFolder():
+    log('Preparing ContentFolder for Studio')
+
+    content_folder = getStudioFolderPath() + r"\\content/"
 
     def func():
-        # Studio often ignores requests to kill, we should retry until it closes
-        requestKillStudioProcess()
-
-        def poll():
-            regKey = winreg.OpenKey(
-                winreg.HKEY_CURRENT_USER, r'Software\\Roblox\\RobloxStudio', access=winreg.KEY_READ)
-            winreg.QueryValueEx(regKey, r'ContentFolder')
-            winreg.CloseKey(regKey)
-
-        # Poll for up to 5 seconds and then start over
-        retryUntilSuccess(poll, 5)
+        regKey = winreg.OpenKey(winreg.HKEY_CURRENT_USER, r'Software\\Roblox\\RobloxStudio', access=winreg.KEY_WRITE)
+        winreg.SetValueEx(regKey, r'ContentFolder', 0, winreg.REG_SZ, content_folder)
+        winreg.CloseKey(regKey)
 
     retryUntilSuccess(func)
 
@@ -158,15 +152,11 @@ def createSettingsFile():
 prepareStudioLogin()
 launcherPath = downloadStudioLauncher()
 studioPath = installStudio(launcherPath)
-
-# We need to wait between each action here to reduce the chance of studio crashing
-time.sleep(5)
-waitForContentPath()
+forceKillStudioProcess()
+prepareContentFolder()
 createPluginsDirectory()
 removeAutoSaveDirectory()
 createSettingsFile()
-time.sleep(5)
-forceKillStudioProcess()
 
 log('Roblox Studio has been installed')
 exit(0)

--- a/install.py
+++ b/install.py
@@ -83,20 +83,11 @@ def forceKillStudioProcess():
     os.system("taskkill /f /im RobloxStudioBeta.exe")
 
 
-versions_dir = r"C:\\Program Files (x86)\\Roblox\\Versions\\"
-
-
-def getStudioFolderPath():
-    for child in os.listdir(versions_dir):
-        child_path = versions_dir + child
-        if os.path.exists(child_path + r"\\RobloxStudioBeta.exe"):
-            return child_path
-
-
-def prepareContentFolder():
+def prepareContentFolder(studioPath):
     log('Preparing ContentFolder for Studio')
 
-    content_folder = getStudioFolderPath() + r"\\content/"
+    # Studio adds a forward slash to the end, not sure if this is intentional..
+    content_folder = os.path.dirname(studioPath) + r"\\content/"
 
     def func():
         try:
@@ -158,7 +149,7 @@ prepareStudioLogin()
 launcherPath = downloadStudioLauncher()
 studioPath = installStudio(launcherPath)
 forceKillStudioProcess()
-prepareContentFolder()
+prepareContentFolder(studioPath)
 createPluginsDirectory()
 removeAutoSaveDirectory()
 createSettingsFile()

--- a/install.py
+++ b/install.py
@@ -7,6 +7,7 @@ import psutil
 import winreg  # pylint: disable=import-error
 import pathlib
 import shutil
+import logging
 
 
 def log(string):
@@ -20,6 +21,7 @@ def retryUntilSuccess(func, timeout=0):
             func()
             return
         except:
+            logging.exception("")
             time.sleep(0.1)
     raise RuntimeError("Retry timed out.")
 


### PR DESCRIPTION
Installation has been broken recently.. and I'm not 100% sure why, but I think it's that `ContentFolder` is not being set in the registry?

Was able to fix it by force killing Roblox Studio and setting `ContentFolder` manually.

I have basically zero experience with Python, so feel free to clean up the code. 😅 

